### PR TITLE
add id attribute to node based on id

### DIFF
--- a/src/lib/Nodes/index.svelte
+++ b/src/lib/Nodes/index.svelte
@@ -45,6 +45,7 @@
     border-color: {node.borderColor}; 
     border-radius: {node.borderRadius}px;
     color: {node.textColor};"
+  id="svelvet-{node.id}"
 >
   <slot />
 </div>


### PR DESCRIPTION
Add an id attribute to the node. This allows for easier control styling using the clickCalback
```
clickCallback: (el) => {
    let node = document.getElementById(el.id);
   ...
    }
```