### PR TITLE
Mouseup bug, scale adjusted movement

### DIFF
--- a/src/lib/Containers/GraphView/index.svelte
+++ b/src/lib/Containers/GraphView/index.svelte
@@ -23,7 +23,7 @@
   export let key: string;
 
   const svelvetStore = findOrCreateStore(key);
-  const { nodeSelected, backgroundStore, widthStore, heightStore } = svelvetStore;
+  const { nodeSelected, backgroundStore, widthStore, heightStore, scaleStore } = svelvetStore;
 
   const gridSize = 15;
   const dotSize = 10;
@@ -58,6 +58,8 @@
     d3.select(`.Edges-${key} g`).attr('transform', e.transform);
     // transform div elements (nodes)
     let transform = d3.zoomTransform(this);
+		// subscribes scale level to store to adjust drag values
+		$scaleStore = transform.k
     // selects and transforms all node divs from class 'Node'
     d3.select(`.Node-${key}`)
       .style(

--- a/src/lib/stores/store.ts
+++ b/src/lib/stores/store.ts
@@ -10,6 +10,7 @@ interface CoreSvelvetStore {
   backgroundStore: Writable<boolean>;
   nodeIdSelected: Writable<number>;
   nodeSelected: Writable<boolean>;
+	scaleStore: Writable<number>;
 }
 
 interface SvelvetStore extends CoreSvelvetStore {
@@ -33,7 +34,8 @@ export function findOrCreateStore(key: string): SvelvetStore {
     heightStore: writable(600),
     backgroundStore: writable(false),
     nodeSelected: writable(false),
-    nodeIdSelected: writable(-1)
+    nodeIdSelected: writable(-1),
+		scaleStore: writable(1)
   };
 
   // update position of selected node
@@ -41,8 +43,8 @@ export function findOrCreateStore(key: string): SvelvetStore {
     coreSvelvetStore.nodesStore.update((n) => {
       n.forEach((node: Node) => {
         if (node.id === nodeID) {
-          node.position.x += e.movementX;
-          node.position.y += e.movementY;
+          node.position.x += e.movementX*(1/get(coreSvelvetStore.scaleStore));
+          node.position.y += e.movementY*(1/get(coreSvelvetStore.scaleStore));
         }
       });
       return [...n];


### PR DESCRIPTION
As noted in issue #91, node positioning is not adjusting to the zoom scale, which breaks the mouseup event that stops movement.

This pr addresses this by adding in a store that is subscribed to the scale value provided by d3 and adjusts the movement(Axis) value setting the node positions.

Seamus