### PR TITLE
[fix] release dragging even if mouse exits div

### DIFF
--- a/src/lib/Nodes/index.svelte
+++ b/src/lib/Nodes/index.svelte
@@ -30,6 +30,14 @@
       moved = true;
     }
   }}
+  on:mouseup={(e) => {
+    moving = false;
+    $nodeSelected = false;
+    if (!moved && node.id == $nodeIdSelected) {
+      onNodeClick(e, node.id);
+    }
+    moved = false;
+  }}
 />
 
 <div
@@ -52,14 +60,6 @@
     moving = true;
     $nodeIdSelected = node.id;
     $nodeSelected = true;
-  }}
-  on:mouseup={(e) => {
-    moving = false;
-    $nodeSelected = false;
-    if (!moved && node.id == $nodeIdSelected) {
-      onNodeClick(e, node.id);
-    }
-    moved = false;
   }}
   class="Node"
   style="left: {node.position.x}px;


### PR DESCRIPTION
This fixes a bug where a node isn't released if the users mouse exits the node's div while dragging.  By moving the `mouseup` event listener to the window, the `dragging` state should never be improperly stuck in the `true` state.

Here is a demonstration of the bug:

https://user-images.githubusercontent.com/55504972/196559411-31a38ba6-7b45-4d6c-869d-2393ba169b36.mp4
