### PR TITLE
Restored Mobile Functionality

### DIFF
--- a/NPM Package/svelvet/stores/store.js
+++ b/NPM Package/svelvet/stores/store.js
@@ -52,8 +52,23 @@ export function findOrCreateStore(key) {
     // This is the function handler for the touch event on mobile to select a node.
     const onTouchMove = (e, nodeID) => {
             coreSvelvetStore.nodesStore.update((n) => {
+                // restores mobile functionality
+                n.forEach(node => {
+                    if (node.id === nodeID) {
+                      //calculates the location of the selected node
+                      const { x, y, width, height } = e.target.getBoundingClientRect();
+                      const offsetX = ((e.touches[0].clientX - x) / width) * e.target.offsetWidth;
+                      const offsetY = ((e.touches[0].clientY - y) / height) * e.target.offsetHeight;
+                      // centers the node consistently under the user's touch
+                      node.position.x += offsetX - node.width / 2;
+                      node.position.y += offsetY - node.height / 2;
+                    }
+                  });
+                  return [...n];
+                });
+            /*  Svelvet 4.0 dev code see:
+                https://github.com/open-source-labs/Svelvet/blob/main/NPM%20Package/svelvet/Future%20Iteration/ParentNode.md
                 const correctNode = n.find((node) => node.id === nodeID);
-    
                 const { x, y, width, height } = e.target.getBoundingClientRect();
                 const offsetX = ((e.touches[0].clientX - x) / width) * e.target.offsetWidth;
                 const offsetY = ((e.touches[0].clientY - y) / height) * e.target.offsetHeight;
@@ -77,6 +92,7 @@ export function findOrCreateStore(key) {
                 }
             });
             return [...n];
+            */
     };
 
     const nodeIdSelected = coreSvelvetStore.nodeIdSelected;


### PR DESCRIPTION
Touch events no longer worked. I looked into the [ParentNode.md](https://github.com/open-source-labs/Svelvet/blob/main/NPM%20Package/svelvet/Future%20Iteration/ParentNode.md) and found that the original Svelvet 2.0 code was uncommented and the Svelvet 4.0 code was commented out. However, in the actual Npm package I found the opposite. I added the 2.0 code and commented out the 4.0 code for future contributors to work on.
Resolving issue https://github.com/open-source-labs/Svelvet/issues/140.