### PR TITLE
Hide edge anchor option

### DIFF
--- a/NPM Package/svelvet/Nodes/index.svelte
+++ b/NPM Package/svelvet/Nodes/index.svelte
@@ -135,7 +135,9 @@
   <DeleteAnchor {key} {node} width={nodeWidth || node.width} height={nodeHeight || node.height} position={node.targetPosition || 'top'} role={'target'} />
 {/if}
   <!-- this anchor is the target-->
-  <EdgeAnchor {key} {node} width={nodeWidth || node.width} height={nodeHeight || node.height} position={node.targetPosition || 'top'} role={'target'} /> 
+  {#if !node?.showEdgeAnchor}
+    <EdgeAnchor {key} {node} width={nodeWidth || node.width} height={nodeHeight || node.height} position={node.targetPosition || 'top'} role={'target'} /> 
+  {/if}
     <!-- This executes if node.image is present without node.label -->
     {#if node.image}
       <img
@@ -155,7 +157,9 @@
       </div>
     {/if}
     <!-- this anchor is the source-->
-    <EdgeAnchor {key} {node} width={nodeWidth || node.width} height={nodeHeight || node.height} position={node.sourcePosition || 'bottom'} role={'source'} />
+    {#if !node?.showEdgeAnchor}
+      <EdgeAnchor {key} {node} width={nodeWidth || node.width} height={nodeHeight || node.height} position={node.sourcePosition || 'bottom'} role={'source'} />
+    {/if}
 </div>
 
 <style>

--- a/NPM Package/svelvet/types/types.d.ts
+++ b/NPM Package/svelvet/types/types.d.ts
@@ -15,6 +15,7 @@ export interface Node<T = any> {
     clickCallback?: Function;
     image?: boolean;
     src?: string;
+    showEdgeAnchor?: boolean;
     sourcePosition?: 'left' | 'right' | 'top' | 'bottom';
     targetPosition?: 'left' | 'right' | 'top' | 'bottom';
 }

--- a/src/routes/docs/custom-nodes.svelte
+++ b/src/routes/docs/custom-nodes.svelte
@@ -17,6 +17,7 @@
     ['borderRadius', 'number'],
     ['clickCallback', 'Function'],
     ['childNodes', 'Array of numbers, put other nodes id\'s in here'],
+    ['showEdgeAnchor', 'boolean']
   ];
 </script>
 


### PR DESCRIPTION
Thanks for making this library!

I personally don't need a lot of the interactivity features from this tool, so it would be nice to disable some of it.
This PR disables the rendering of handles on a given node when given a showEdgeAnchor:false parameter.

Feel free to rename it to hideEdgeAnchor, hideHandles, etc,... I don't know what naming conventions you use :)