### PR TITLE
FIX: repl related fixes (see comments for details)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "svelte-moveable": "^0.34.1",
         "svelte-parallax": "^0.6.0",
         "svelvet": "^5.0.7",
-        "svelvet-lime": "^6.0.22",
+        "svelvetrabbits": "^4.10.3",
         "uuid": "^9.0.0",
         "yootils": "^0.3.1"
       },
@@ -7770,10 +7770,10 @@
         "d3-zoom": "^3.0.0"
       }
     },
-    "node_modules/svelvet-lime": {
-      "version": "6.0.22",
-      "resolved": "https://registry.npmjs.org/svelvet-lime/-/svelvet-lime-6.0.22.tgz",
-      "integrity": "sha512-KYD8W+d4i9PRALX5XJACS1iKghmAkuG2coIWs2Z900nE5WrzqRcbpxPHwXkPmTQc+/EhJeZ/GS/ijWKV7tWOXw==",
+    "node_modules/svelvetrabbits": {
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/svelvetrabbits/-/svelvetrabbits-4.10.3.tgz",
+      "integrity": "sha512-I94sW37rSt0i0z6gr2grxANDBqfb5ywyERrLlZgQeTX/h/FY+OS+9oOxiM4cJBWk+DXAoQwyV2whu87jHpvpIQ==",
       "dependencies": {
         "d3-zoom": "^3.0.0"
       }
@@ -14412,10 +14412,10 @@
         "d3-zoom": "^3.0.0"
       }
     },
-    "svelvet-lime": {
-      "version": "6.0.22",
-      "resolved": "https://registry.npmjs.org/svelvet-lime/-/svelvet-lime-6.0.22.tgz",
-      "integrity": "sha512-KYD8W+d4i9PRALX5XJACS1iKghmAkuG2coIWs2Z900nE5WrzqRcbpxPHwXkPmTQc+/EhJeZ/GS/ijWKV7tWOXw==",
+    "svelvetrabbits": {
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/svelvetrabbits/-/svelvetrabbits-4.10.3.tgz",
+      "integrity": "sha512-I94sW37rSt0i0z6gr2grxANDBqfb5ywyERrLlZgQeTX/h/FY+OS+9oOxiM4cJBWk+DXAoQwyV2whu87jHpvpIQ==",
       "requires": {
         "d3-zoom": "^3.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "svelte-moveable": "^0.34.1",
     "svelte-parallax": "^0.6.0",
     "svelvet": "^5.0.7",
-    "svelvet-lime": "^6.0.22",
+    "svelvetrabbits": "^4.10.3",
     "uuid": "^9.0.0",
     "yootils": "^0.3.1"
   }

--- a/src/lib/docs/Tutorials.md
+++ b/src/lib/docs/Tutorials.md
@@ -14,8 +14,9 @@ This command will create documentation in root folder `./docs`.
 
 ## Publishing to npm
 
-- create an account on npm.js
-- Within the `src/lib` directory, type `npm version patch` to increment version number
+- create an account on npm.js. You can skip this step if you already have an account
+- log in with `$ npm login`
+- Within the `src/lib` directory, type `npm version patch` to increment version number. Or if you want a new name, you can modify `src/lib/package.json` directly
 - In the base directory, type `npm run package`. This will use svelte-kit's package feature to create an npm package in `./package`.
 - Within the `./package` directory, type `npm publish` to publish to npm. Note that you cannot "overwrite" previous publishes, you must increment the version number
 

--- a/src/repl/CodeMirror.svelte
+++ b/src/repl/CodeMirror.svelte
@@ -30,15 +30,20 @@
     edgeToggle,
     nodeToggle,
     advancedEdgeToggle,
-    advancedNodeToggle
+    advancedNodeToggle,
   } from '../playgroundStore';
   import NodeModal from './Output/NodeModal.svelte';
   import { onMount, createEventDispatcher } from 'svelte';
   import { writable } from 'svelte/store';
   import Message from './Message.svelte';
-  import { addCodeToDB, getCodeFromDB, updateCodeInDB, deleteCodeFromDB } from '../supabase-db';
+  import {
+    addCodeToDB,
+    getCodeFromDB,
+    updateCodeInDB,
+    deleteCodeFromDB,
+  } from '../supabase-db';
   import { userInfoStore } from '../authStoreTs';
-  import {clickOutside} from './shortcuts/clickoutside'
+  import { clickOutside } from './shortcuts/clickoutside';
 
   const dispatch = createEventDispatcher();
 
@@ -109,7 +114,7 @@
   export function markText({ from, to }) {
     if (editor)
       editor.markText(editor.posFromIndex(from), editor.posFromIndex(to), {
-        className: 'mark-text'
+        className: 'mark-text',
       });
   }
 
@@ -132,7 +137,10 @@
     await copyToClipboard();
   }
 
-  export async function getCodeEditorValue(id: number, diagramName: string): Promise<void> {
+  export async function getCodeEditorValue(
+    id: number,
+    diagramName: string
+  ): Promise<void> {
     const codeToSave = editor.getValue();
     let found = false;
 
@@ -154,7 +162,9 @@
       editor.setValue('');
       alert('Diagram saved to database successfully!');
     } else if (!diagramName) {
-      alert('Please provide a name for your diagram before attempting to save.');
+      alert(
+        'Please provide a name for your diagram before attempting to save.'
+      );
     } else if (!found) {
       alert(
         'You have reached the limit in terms of how many diagrams you can store. Please delete one to save a new diagram.'
@@ -184,19 +194,19 @@
   const modes = {
     js: {
       name: 'javascript',
-      json: false
+      json: false,
     },
     json: {
       name: 'javascript',
-      json: true
+      json: true,
     },
     svelte: {
       name: 'handlebars',
-      base: 'text/html'
+      base: 'text/html',
     },
     md: {
-      name: 'markdown'
-    }
+      name: 'markdown',
+    },
   };
 
   const refs = {};
@@ -222,7 +232,7 @@
         { line, ch },
         { line, ch: ch + 1 },
         {
-          className: 'error-loc'
+          className: 'error-loc',
         }
       );
 
@@ -258,7 +268,7 @@
           editor.setValue(
             code ||
               `<script>
-  import Svelvet from 'svelvet';
+  import Svelvet from 'svelvetrabbits';
 	const initialNodes = [
 	  {
 		id: 1,
@@ -357,7 +367,7 @@
       tabSize: 2,
       value: '',
       mode: modes[mode] || {
-        name: mode
+        name: mode,
       },
       readOnly: readonly,
       autoCloseBrackets: true,
@@ -373,11 +383,11 @@
           cm.foldCode(cm.getCursor());
         },
         // allow escaping the CodeMirror with Esc Tab
-        'Esc Tab': false
+        'Esc Tab': false,
       }),
       foldGutter: true,
       gutters: ['CodeMirror-linenumbers', 'CodeMirror-foldgutter'],
-      theme
+      theme,
     };
 
     if (!tab) {
@@ -413,23 +423,19 @@
   function sleep(ms) {
     return new Promise((fulfil) => setTimeout(fulfil, ms));
   }
-//   let newNode = `{
-// id: ${$idNumber},
-//  position: { x:${$positionX}, y:${$positionY}},
-//  data: { label: "${$data}" },
-//  width: ${$width},
-//  height: ${$height},
-//  borderColor: "${$borderColor}",
-//  borderRadius: ${$borderRadius},
-//  bgColor: "${$bgColor}",
-//  textColor: "${$textColor}"
-// },`;
+  //   let newNode = `{
+  // id: ${$idNumber},
+  //  position: { x:${$positionX}, y:${$positionY}},
+  //  data: { label: "${$data}" },
+  //  width: ${$width},
+  //  height: ${$height},
+  //  borderColor: "${$borderColor}",
+  //  borderRadius: ${$borderRadius},
+  //  bgColor: "${$bgColor}",
+  //  textColor: "${$textColor}"
+  // },`;
 
   $: if ($buildToggle === true) {
-
-
-
-    
     let newNode = `{
 id: ${$idNumber},
  position: { x:${$positionX}, y:${$positionY}},
@@ -445,35 +451,47 @@ id: ${$idNumber},
  clickCallback: node => console.log(node),
 },`;
 
-if($edgeToggle === true && $nodeToggle === false && $advancedNodeToggle === false) { newNode = ''
-}
-  let newEdge = `{ id: 'e${$source}-${$target}', source: ${$source}, target: ${$target}, label: '${$edgeLabel}', animate: ${$animate}, arrow: ${$arrow}, edgeColor: '${$edgeColor}', labelBgColor: '${$labelBgColor}', labelTextColor: '${$labelTextColor}', },`;
+    if (
+      $edgeToggle === true &&
+      $nodeToggle === false &&
+      $advancedNodeToggle === false
+    ) {
+      newNode = '';
+    }
+    let newEdge = `{ id: 'e${$source}-${$target}', source: ${$source}, target: ${$target}, label: '${$edgeLabel}', animate: ${$animate}, arrow: ${$arrow}, edgeColor: '${$edgeColor}', labelBgColor: '${$labelBgColor}', labelTextColor: '${$labelTextColor}', },`;
 
-    editor.setValue(code || $editStrP1 + newNode + $editStrP2 + newEdge + editStrP3);
-   $buildToggle = $nodeToggle = $edgeToggle = $advancedNodeToggle = $advancedEdgeToggle = false;
+    editor.setValue(
+      code || $editStrP1 + newNode + $editStrP2 + newEdge + editStrP3
+    );
+    $buildToggle =
+      $nodeToggle =
+      $edgeToggle =
+      $advancedNodeToggle =
+      $advancedEdgeToggle =
+        false;
 
-    $idNumber ++;
+    $idNumber++;
     $editStrP1 += newNode;
     $editStrP2 += newEdge;
     $positionX += 20;
     $positionY += 20;
     $source++;
     $target++;
-
   }
 </script>
+
 <!-- <div  use:clickOutside on:outclick={() => ($inputToggle = false)}> -->
-  {#if $inputToggle === true}
-  <NodeModal/>
-  {/if}
+{#if $inputToggle === true}
+  <NodeModal />
+{/if}
 <!-- </div> -->
 
 <div class="codemirror-container" bind:offsetWidth={w} bind:offsetHeight={h}>
   <textarea bind:this={refs.editor} readonly value={code} />
-  
+
   {#if !CodeMirror}
     <pre style="position: absolute; left: 0; top: 0">{code}</pre>
-   
+
     <div style="position: absolute; width: 100%; bottom: 0">
       <Message kind="info">loading editor...</Message>
     </div>

--- a/src/routes/playground/index.svelte
+++ b/src/routes/playground/index.svelte
@@ -1,5 +1,4 @@
 <script>
-
   // REPL
   import { onMount } from 'svelte';
   import { browser } from '$app/env';
@@ -7,9 +6,9 @@
   import black_logo from '../../assets/Logo 1 black.svg';
   import Repl from '../../repl';
   import PlaygoundTips from '../../repl/shortcuts/PlaygoundTips.svelte';
-  import {tipsToggle, docsToggle} from '../../playgroundStore';
+  import { tipsToggle, docsToggle } from '../../playgroundStore';
   import DocsModal from '../../repl/shortcuts/DocsModal.svelte';
-  
+
   let { user_name } = userInfoStore;
 
   const rollupUrl = `https://unpkg.com/rollup@1/dist/rollup.browser.js`;
@@ -23,43 +22,53 @@
         {
           name: 'App',
           type: 'svelte',
-          source: ``
-        }
-      ]
+          source: ``,
+        },
+      ],
     })
   );
 </script>
 
 <!-- if there's a username, render the name in the playground? else just have playground? follow the svelvet font on the top left? -->
 {#if user_name}
-  <div class="user-welcome text-3xl text-gray-700 font-nunito font-medium tracking-wide">
+  <div
+    class="user-welcome text-3xl text-gray-700 font-nunito font-medium tracking-wide"
+  >
     {$user_name} PLAYGR<img src={black_logo} alt="Svelvet logo in black" />UND
   </div>
 {:else}
-  <div class="user-welcome text-3xl text-gray-700 font-nunito font-medium tracking-wide">
+  <div
+    class="user-welcome text-3xl text-gray-700 font-nunito font-medium tracking-wide"
+  >
     {$user_name}PLAYGR<img src={black_logo} alt="Svelvet logo in black" />UND
   </div>
 {/if}
 <!-- playground tips and tricks  -->
-{#if ($tipsToggle === true)}
+<!-- {#if $tipsToggle === true}
   <PlaygoundTips />
 {/if}
-{#if ($docsToggle === true)}
-<DocsModal />
-{/if}
+{#if $docsToggle === true}
+  <DocsModal />
+{/if} -->
 
 <!-- REPL -->
-<!-- <div class="REPL-container" style="inline-size: 400px; block-size: 400px;"> -->
 <div class="REPL-container">
-  {#if browser}
+  <!-- Replaced  repl with stackblitz until we can figure out the store  -->
+  <!-- {#if browser}
     <Repl {rollupUrl} {svelteUrl} embedded relaxed bind:this={repl} />
-  {/if}
+  {/if} -->
+
+  <iframe
+    src="https://stackblitz.com/edit/sveltejs-kit-template-default-wyqprd?embed=1&file=src/routes/+layout.svelte"
+    style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
+    title="Custom Svelte Components"
+    allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
+    sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
+  />
 </div>
+
 <!-- <meta http-equiv="refresh" content="15"> -->
-
 <style>
-
-
   @media screen and (max-width: 539px) {
     .REPL-container {
       display: block;

--- a/src/routes/playground/index.svelte
+++ b/src/routes/playground/index.svelte
@@ -6,11 +6,6 @@
 </script>
 
 <div class="REPL-container">
-  <!-- Replaced  repl with stackblitz until we can figure out the store  -->
-  <!-- {#if browser}
-    <Repl {rollupUrl} {svelteUrl} embedded relaxed bind:this={repl} />
-  {/if} -->
-
   <p>
     If you are using a non-chromium based browser, use this direct <a
       href="https://stackblitz.com/edit/sveltejs-kit-template-default-wyqprd?file=src/routes/+layout.svelte"
@@ -32,28 +27,10 @@
   @media screen and (max-width: 539px) {
     .REPL-container {
       display: block;
-      /* margin: 2em auto 2em; */
-      /* position: absolute; */
-      /* width: 80%; */
-      /* height: 80%; */
       inline-size: 100%;
       block-size: 50em;
       margin-left: 0.25em;
       margin-right: 0.25em;
-
-      /* inline-size: 800px;
-      block-size: 800px; */
-    }
-    .user-welcome {
-      font-size: 24px;
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      margin-top: 0.25em;
-    }
-    .user-welcome img {
-      display: inline-block;
-      height: 1.85rem;
     }
   }
 
@@ -61,23 +38,8 @@
     .REPL-container {
       display: block;
       margin: 2em auto 2em;
-      /* position: absolute; */
-      /* width: 80%; */
-      /* height: 80%; */
       inline-size: 80%;
       block-size: 50em;
-
-      /* inline-size: 800px;
-      block-size: 800px; */
-    }
-    .user-welcome {
-      display: flex;
-      justify-content: flex-end;
-      padding: 1em 1em 1em;
-      padding-right: 2em;
-    }
-    .user-welcome img {
-      height: 1.85rem;
     }
   }
 </style>

--- a/src/routes/playground/index.svelte
+++ b/src/routes/playground/index.svelte
@@ -1,62 +1,22 @@
+<!-- 
+  We have replaced the repl with StackBlitz for now until the repl store can be fixed.
+  To see original repl component, see src/routes/playground-backup/index.svelte
+ -->
 <script>
-  // REPL
-  import { onMount } from 'svelte';
-  import { browser } from '$app/env';
-  import { userInfoStore } from '../../authStoreTs';
-  import black_logo from '../../assets/Logo 1 black.svg';
-  import Repl from '../../repl';
-  import PlaygoundTips from '../../repl/shortcuts/PlaygoundTips.svelte';
-  import { tipsToggle, docsToggle } from '../../playgroundStore';
-  import DocsModal from '../../repl/shortcuts/DocsModal.svelte';
-
-  let { user_name } = userInfoStore;
-
-  const rollupUrl = `https://unpkg.com/rollup@1/dist/rollup.browser.js`;
-  const svelteUrl = `https://unpkg.com/svelte@3`;
-
-  let repl = null;
-
-  onMount(() =>
-    repl.set({
-      components: [
-        {
-          name: 'App',
-          type: 'svelte',
-          source: ``,
-        },
-      ],
-    })
-  );
 </script>
 
-<!-- if there's a username, render the name in the playground? else just have playground? follow the svelvet font on the top left? -->
-{#if user_name}
-  <div
-    class="user-welcome text-3xl text-gray-700 font-nunito font-medium tracking-wide"
-  >
-    {$user_name} PLAYGR<img src={black_logo} alt="Svelvet logo in black" />UND
-  </div>
-{:else}
-  <div
-    class="user-welcome text-3xl text-gray-700 font-nunito font-medium tracking-wide"
-  >
-    {$user_name}PLAYGR<img src={black_logo} alt="Svelvet logo in black" />UND
-  </div>
-{/if}
-<!-- playground tips and tricks  -->
-<!-- {#if $tipsToggle === true}
-  <PlaygoundTips />
-{/if}
-{#if $docsToggle === true}
-  <DocsModal />
-{/if} -->
-
-<!-- REPL -->
 <div class="REPL-container">
   <!-- Replaced  repl with stackblitz until we can figure out the store  -->
   <!-- {#if browser}
     <Repl {rollupUrl} {svelteUrl} embedded relaxed bind:this={repl} />
   {/if} -->
+
+  <p>
+    If you are using a non-chromium based browser, use this direct <a
+      href="https://stackblitz.com/edit/sveltejs-kit-template-default-wyqprd?file=src/routes/+layout.svelte"
+      style="color: blue">link</a
+    > instead
+  </p>
 
   <iframe
     src="https://stackblitz.com/edit/sveltejs-kit-template-default-wyqprd?embed=1&file=src/routes/+layout.svelte"

--- a/src/routes/repl/index.svelte
+++ b/src/routes/repl/index.svelte
@@ -1,0 +1,114 @@
+<script>
+  // REPL
+  import { onMount } from 'svelte';
+  import { browser } from '$app/env';
+  import { userInfoStore } from '../../authStoreTs';
+  import black_logo from '../../assets/Logo 1 black.svg';
+  import Repl from '../../repl';
+  import PlaygoundTips from '../../repl/shortcuts/PlaygoundTips.svelte';
+  import { tipsToggle, docsToggle } from '../../playgroundStore';
+  import DocsModal from '../../repl/shortcuts/DocsModal.svelte';
+
+  let { user_name } = userInfoStore;
+
+  const rollupUrl = `https://unpkg.com/rollup@1/dist/rollup.browser.js`;
+  const svelteUrl = `https://unpkg.com/svelte@3`;
+
+  let repl = null;
+
+  onMount(() =>
+    repl.set({
+      components: [
+        {
+          name: 'App',
+          type: 'svelte',
+          source: ``,
+        },
+      ],
+    })
+  );
+</script>
+
+<!-- if there's a username, render the name in the playground? else just have playground? follow the svelvet font on the top left? -->
+{#if user_name}
+  <div
+    class="user-welcome text-3xl text-gray-700 font-nunito font-medium tracking-wide"
+  >
+    {$user_name} PLAYGR<img src={black_logo} alt="Svelvet logo in black" />UND
+  </div>
+{:else}
+  <div
+    class="user-welcome text-3xl text-gray-700 font-nunito font-medium tracking-wide"
+  >
+    {$user_name}PLAYGR<img src={black_logo} alt="Svelvet logo in black" />UND
+  </div>
+{/if}
+<!-- playground tips and tricks  -->
+{#if $tipsToggle === true}
+  <PlaygoundTips />
+{/if}
+{#if $docsToggle === true}
+  <DocsModal />
+{/if}
+
+<!-- REPL -->
+<div class="REPL-container">
+  {#if browser}
+    <Repl {rollupUrl} {svelteUrl} embedded relaxed bind:this={repl} />
+  {/if}
+</div>
+
+<!-- <meta http-equiv="refresh" content="15"> -->
+<style>
+  @media screen and (max-width: 539px) {
+    .REPL-container {
+      display: block;
+      /* margin: 2em auto 2em; */
+      /* position: absolute; */
+      /* width: 80%; */
+      /* height: 80%; */
+      inline-size: 100%;
+      block-size: 50em;
+      margin-left: 0.25em;
+      margin-right: 0.25em;
+
+      /* inline-size: 800px;
+      block-size: 800px; */
+    }
+    .user-welcome {
+      font-size: 24px;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      margin-top: 0.25em;
+    }
+    .user-welcome img {
+      display: inline-block;
+      height: 1.85rem;
+    }
+  }
+
+  @media screen and (min-width: 540px) {
+    .REPL-container {
+      display: block;
+      margin: 2em auto 2em;
+      /* position: absolute; */
+      /* width: 80%; */
+      /* height: 80%; */
+      inline-size: 80%;
+      block-size: 50em;
+
+      /* inline-size: 800px;
+      block-size: 800px; */
+    }
+    .user-welcome {
+      display: flex;
+      justify-content: flex-end;
+      padding: 1em 1em 1em;
+      padding-right: 2em;
+    }
+    .user-welcome img {
+      height: 1.85rem;
+    }
+  }
+</style>


### PR DESCRIPTION
The REPL route contains a StackBlitz embed. Stackblitz embeds do not run on non-chromium browsers (ie, Firefox).

This commit adds a note on the REPL route telling users that the REPL will not work on non-chromium browsers, and gives a direct link to Stackblitz (which does run in firefox).

This commit also adds a hidden route /repl which links to the old REPL, which itself links to svelvetcakes and is functional. 