### PR TITLE
Add Custom Theme(s) to Svelvet Container and ThemeToggle

### DIFF
--- a/src/lib/components/ThemeToggle/ThemeToggle.svelte
+++ b/src/lib/components/ThemeToggle/ThemeToggle.svelte
@@ -1,24 +1,27 @@
 <script lang="ts">
 	import type { Writable } from 'svelte/store';
-	import type { Theme, ThemeGroup, CSSColorString } from '$lib/types';
+	import type { ThemeGroup, CSSColorString, Theme } from '$lib/types';
 	import { getContext } from 'svelte';
 	import { THEMES } from '$lib/constants/themes';
 
 	const themeStore: Writable<ThemeGroup> = getContext('themeStore');
+	const altThemeFromContext: ThemeGroup = getContext('altTheme');
 
-	export let main: Theme = 'dark';
-	export let alt: Theme = 'light';
+	export let main: ThemeGroup | Theme = $themeStore;
+	export let alt: ThemeGroup | Theme = altThemeFromContext;
 	export let corner = 'NE';
 	export let bgColor: CSSColorString | null = null;
 	export let iconColor: CSSColorString | null = null;
 
-	let current: Theme = main;
+	let mainTheme = typeof main === 'string' ? THEMES[main] : main;
+	let altTheme = typeof alt === 'string' ? THEMES[alt] : alt;
+	let current: ThemeGroup = mainTheme;
 
 	function toggleTheme() {
-		current = current === main ? alt : main;
+		current = current === mainTheme ? altTheme : mainTheme;
 	}
 
-	$: $themeStore = THEMES[current];
+	$: $themeStore = current;
 </script>
 
 <div
@@ -31,7 +34,9 @@
 	class:NW={corner === 'NW'}
 >
 	<button on:mousedown|stopPropagation={toggleTheme} on:touchstart|stopPropagation={toggleTheme}>
-		<span class="material-symbols-outlined">{current === main ? 'light_mode' : 'dark_mode'}</span>
+		<span class="material-symbols-outlined"
+			>{current === mainTheme ? 'light_mode' : 'dark_mode'}</span
+		>
 	</button>
 </div>
 

--- a/src/lib/components/ThemeToggle/ThemeToggle.svelte
+++ b/src/lib/components/ThemeToggle/ThemeToggle.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import type { Writable } from 'svelte/store';
-	import type { ThemeGroup, CSSColorString, Theme } from '$lib/types';
+	import type { Theme, ThemeGroup, CSSColorString } from '$lib/types';
 	import { getContext } from 'svelte';
 	import { THEMES } from '$lib/constants/themes';
 
@@ -18,6 +18,7 @@
 	let current: ThemeGroup = mainTheme;
 
 	function toggleTheme() {
+		console.log(THEMES[main], THEMES[alt]);
 		current = current === mainTheme ? altTheme : mainTheme;
 	}
 

--- a/src/lib/types/graph.ts
+++ b/src/lib/types/graph.ts
@@ -13,7 +13,7 @@ import type {
 	InputStore,
 	OutputStore,
 	GraphDimensions,
-	Theme
+	ThemeGroup
 } from '.';
 import type { ComponentType } from 'svelte';
 
@@ -47,7 +47,7 @@ export interface Graph {
 	edges: EdgeStore;
 	edge: ComponentType | null;
 	groupBoxes: GroupBoxStore;
-	theme: Writable<Theme>;
+	theme: Writable<ThemeGroup>;
 	editing: Writable<Node | null>;
 	activeGroup: Writable<GroupKey | null>;
 	initialNodePositions: Writable<XYPair[]>;
@@ -59,7 +59,7 @@ export interface GraphConfig {
 	zoom?: number;
 	direction?: 'TD' | 'LR';
 	locked?: boolean;
-	theme?: Theme;
+	theme?: ThemeGroup;
 	translation?: { x: number; y: number };
 	edge?: ComponentType;
 }

--- a/src/lib/utils/creators/createGraph.ts
+++ b/src/lib/utils/creators/createGraph.ts
@@ -7,6 +7,7 @@ import { createDerivedCursorStore } from './createDerivedCursoreStore';
 import { createBoundsStore } from './createBoundsStore';
 import type { GraphConfig } from '$lib/types';
 import { calculateViewportCenter } from '../calculators/calculateViewPortCenter';
+import { THEMES } from '$lib/constants/themes';
 
 export function createGraph(id: GraphKey, config: GraphConfig): Graph {
 	const {
@@ -65,7 +66,7 @@ export function createGraph(id: GraphKey, config: GraphConfig): Graph {
 		groupBoxes: createStore<GroupBox, GroupKey>(),
 		activeGroup: writable(null),
 		initialNodePositions: writable([]),
-		theme: writable(theme || 'light')
+		theme: writable(theme || THEMES['light'])
 	};
 
 	return graph;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,31 +1,18 @@
 <script lang="ts">
-	import { Svelvet, Node, type ThemeGroup } from '$lib';
+	import { Svelvet, Node } from '$lib';
 	import CustomNode from '../example-components/CustomNode.svelte';
 	import CustomEdge from '../example-components/CustomEdge.svelte';
 	import InputNode from '../example-components/InputNode.svelte';
-	import { readable, writable } from 'svelte/store';
+	import { writable } from 'svelte/store';
 	import { setContext } from 'svelte';
 	let customNodeCount = writable(1);
 	let thisNodeCount = writable(3);
 	setContext('customNodeCount', customNodeCount);
 
-	const customTheme = writable(<ThemeGroup>{
-		node: '#AED6F1',
-		map: '#5DADE2',
-		border: '#2874A6',
-		text: '#1F618D',
-		selection: '#5499C7',
-		header: '#3498DB',
-		edge: 'white',
-		anchor: '#85C1E9',
-		controls: '#1B4F72',
-		dots: '#2D9743',
-		alt: '#5DADE2'
-	});
 </script>
 
 <body>
-	<Svelvet edgeStyle="step" edge={CustomEdge} TD zoom={0.6} minimap toggle>
+	<Svelvet edgeStyle="step" edge={CustomEdge} TD theme="dark" zoom={0.6} minimap>
 		{#each { length: $customNodeCount } as _, i}
 			<CustomNode />
 		{/each}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,17 +1,31 @@
 <script lang="ts">
-	import { Svelvet, Node } from '$lib';
+	import { Svelvet, Node, type ThemeGroup } from '$lib';
 	import CustomNode from '../example-components/CustomNode.svelte';
 	import CustomEdge from '../example-components/CustomEdge.svelte';
 	import InputNode from '../example-components/InputNode.svelte';
-	import { writable } from 'svelte/store';
+	import { readable, writable } from 'svelte/store';
 	import { setContext } from 'svelte';
 	let customNodeCount = writable(1);
 	let thisNodeCount = writable(3);
 	setContext('customNodeCount', customNodeCount);
+
+	const customTheme = writable(<ThemeGroup>{
+		node: '#AED6F1',
+		map: '#5DADE2',
+		border: '#2874A6',
+		text: '#1F618D',
+		selection: '#5499C7',
+		header: '#3498DB',
+		edge: 'white',
+		anchor: '#85C1E9',
+		controls: '#1B4F72',
+		dots: '#2D9743',
+		alt: '#5DADE2'
+	});
 </script>
 
 <body>
-	<Svelvet edgeStyle="step" edge={CustomEdge} TD theme="dark" zoom={0.6} minimap>
+	<Svelvet edgeStyle="step" edge={CustomEdge} TD zoom={0.6} minimap toggle>
 		{#each { length: $customNodeCount } as _, i}
 			<CustomNode />
 		{/each}

--- a/src/routes/website/+page.svelte
+++ b/src/routes/website/+page.svelte
@@ -7,12 +7,22 @@
 	import Scale from '../../example-components/test-components/Scale.svelte';
 	import Output from '../../example-components/test-components/Output.svelte';
 	let theme: import('$lib/types').Theme = 'light';
+	let altTheme: import('$lib/types').Theme = 'purple';
 	let zoom = 0.6;
 	let minimapVisible = true;
 </script>
 
 <div class="diagram">
-	<Svelvet fitView="resize" edgeStyle="step" TD {theme} {zoom} controls minimap={minimapVisible}>
+	<Svelvet
+		fitView="resize"
+		edgeStyle="step"
+		TD
+		{theme}
+		{altTheme}
+		{zoom}
+		controls
+		minimap={minimapVisible}
+	>
 		<Group
 			position={{ x: -150, y: -100 }}
 			width={600}
@@ -29,7 +39,7 @@
 		<Output />
 		<span id="state" class="note"> Stateful Anchors</span>
 		<span id="groups" class="note">Group Boxes</span>
-		<ThemeToggle main="light" alt="dark" slot="toggle" />
+		<ThemeToggle main="light" slot="toggle" />
 	</Svelvet>
 </div>
 

--- a/src/routes/website/+page.svelte
+++ b/src/routes/website/+page.svelte
@@ -7,22 +7,12 @@
 	import Scale from '../../example-components/test-components/Scale.svelte';
 	import Output from '../../example-components/test-components/Output.svelte';
 	let theme: import('$lib/types').Theme = 'light';
-	let altTheme: import('$lib/types').Theme = 'purple';
 	let zoom = 0.6;
 	let minimapVisible = true;
 </script>
 
 <div class="diagram">
-	<Svelvet
-		fitView="resize"
-		edgeStyle="step"
-		TD
-		{theme}
-		{altTheme}
-		{zoom}
-		controls
-		minimap={minimapVisible}
-	>
+	<Svelvet fitView="resize" edgeStyle="step" TD {theme} {zoom} controls minimap={minimapVisible}>
 		<Group
 			position={{ x: -150, y: -100 }}
 			width={600}
@@ -39,7 +29,7 @@
 		<Output />
 		<span id="state" class="note"> Stateful Anchors</span>
 		<span id="groups" class="note">Group Boxes</span>
-		<ThemeToggle main="light" slot="toggle" />
+		<ThemeToggle main="dark" alt="light" slot="toggle" />
 	</Svelvet>
 </div>
 


### PR DESCRIPTION
This PR maintains backwards compatibility for passing a theme from the `THEME` enum while adding the ability to pass a custom theme store with the type `Writable<ThemeGroup>`.  

Also added the the Svelvet container is an `altTheme` prop that exposes another `ThemeGroup` to keep sensible defaults when using Toggle component. This does not need to be reactive since it is assigned to the writable store. 

To avoid confusion with the `ThemeToggle` it might make more sense to name these along the lines of "lightTheme" and "darkTheme". 

For example, I changed the order within the theme Toggle component to represent dark-first and make it so that the website example toggles to the theme shown on the icon (so the icon represents the action, not current state).  Please disregard if my mental model is in the minority. 

See custom themes in action by visiting the custom-theme page of the web app. For my use case this works well to keep the Svelvet graph in sync with the rest of the application's theming and avoids some of the pain involved with passing props across multiple components. For example, if using custom css theming (ie tailwindcss) it is non-trivial to convert to a `CSSColorString` and keep it responsive. 

Here is an example usage with only the theme prop (no alt) that comes from global state.

```
  const theme: Writable<String> = getContext('theme');

  let baseTheme: ThemeGroup;
  $: {
    let colors = myThemeColors[`[data-theme=${$Theme}]`];
    
    baseTheme = {
      node: colors.neutral,
      map: colors['base-100'],
      primary: colors.primary,
      border: '#2874A6',
      text: colors['neutral-content'] || 'white',
      selection: '#5499C7',
      header: '#3498DB',
      edge: colors['base-content'],
      anchor: '#85C1E9',
      controls: colors.accent,
      dots: colors.primary,
      alt: colors.neutral,
    };
    console.log(baseTheme)
  }

  let newStore: Writable<ThemeGroup> = writable<ThemeGroup>();
  $: newStore.update((prev) => baseTheme);
```

I'd love to have this as part of the library and am willing to refine this as needed to make that happen. 