### PR TITLE
Make fixedZoom available as a Prop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "svelvet",
-	"version": "7.0.43",
+	"version": "7.0.47",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "svelvet",
-			"version": "7.0.43",
+			"version": "7.0.47",
 			"license": "MIT",
 			"devDependencies": {
 				"@playwright/test": "^1.28.1",

--- a/src/lib/containers/Graph/Graph.svelte
+++ b/src/lib/containers/Graph/Graph.svelte
@@ -367,6 +367,7 @@
 			if (fixedZoom) return;
 			zoomAndTranslate(1, graph.dimensions, graph.transforms, ZOOM_INCREMENT);
 		} else if (key === '0') {
+			if (fixedZoom) return;
 			fitIntoView();
 		} else if (key === 'Control') {
 			$groups['selected'].nodes.set(new Set());

--- a/src/lib/containers/Graph/Graph.svelte
+++ b/src/lib/containers/Graph/Graph.svelte
@@ -308,18 +308,24 @@
 
 		isMovable = true;
 		if (e.touches.length === 2) {
-			startPinching();
+			startPinching(e);
 			initialDistance = $touchDistance;
 			initialScale = $scale;
+		} else {
+			e.preventDefault();
 		}
 	}
 
-	function onTouchEnd() {
+	function onTouchEnd(e: TouchEvent) {
 		isMovable = false;
 		pinching = false;
+		e.preventDefault();
 	}
 
-	function startPinching() {
+	function startPinching(e: TouchEvent) {
+		if (fixedZoom) return;
+		e.preventDefault();
+
 		if (!pinching) {
 			pinching = true;
 			animationFrameId = requestAnimationFrame(handlePinch);
@@ -355,8 +361,10 @@
 		} else if (isArrow(key)) {
 			handleArrowKey(key as Arrow, e);
 		} else if (key === '=') {
+			if (fixedZoom) return;
 			zoomAndTranslate(-1, graph.dimensions, graph.transforms, ZOOM_INCREMENT);
 		} else if (key === '-') {
+			if (fixedZoom) return;
 			zoomAndTranslate(1, graph.dimensions, graph.transforms, ZOOM_INCREMENT);
 		} else if (key === '0') {
 			fitIntoView();
@@ -384,6 +392,7 @@
 
 	function handleScroll(e: WheelEvent) {
 		if (fixedZoom) return;
+		e.preventDefault();
 		const multiplier = e.shiftKey ? 0.15 : 1;
 		const { clientX, clientY, deltaY } = e;
 		const currentTranslation = $translation;
@@ -477,10 +486,10 @@
 	{title}
 	style:width={width ? width + 'px' : '100%'}
 	style:height={height ? height + 'px' : '100%'}
-	on:wheel|preventDefault={handleScroll}
+	on:wheel={handleScroll}
 	on:mousedown|preventDefault|self={onMouseDown}
-	on:touchend|preventDefault={onTouchEnd}
-	on:touchstart|preventDefault|self={onTouchStart}
+	on:touchend={onTouchEnd}
+	on:touchstart|self={onTouchStart}
 	on:keydown={handleKeyDown}
 	on:keyup={handleKeyUp}
 	bind:this={$graphDOMElement}

--- a/src/lib/containers/Svelvet/Svelvet.svelte
+++ b/src/lib/containers/Svelvet/Svelvet.svelte
@@ -28,6 +28,7 @@
 	 * @description Sets initial zoom level of the graph. This value
 	 * features two way binding, so changing it will update the zoom.
 	 */
+	export let fixedZoom = false;
 	export let zoom = 1;
 	export let TD = false;
 	export let editable = false;
@@ -130,6 +131,7 @@
 		{trackpadPan}
 		{modifier}
 		{title}
+		{fixedZoom}
 		on:edgeDrop
 	>
 		{#if mermaid.length}


### PR DESCRIPTION
Hey,

I need this for a project where I want to be able to scroll in Nodes. 
The graph takes over the scroll and touch events so scrolling is not possible.

I added a check to the fixedZoom property so it controls all zoom events (keyboard, pinch and wheel). I also made it possible to allow the fixedZoom property to be set for the Svelvet element.


This is just a quick fix to get it working for my project. If there is interest to merge these changes into main I would be happy to add a few tests.

Cheers!
