### PR TITLE
Feature/grid enhancements

### DIFF
--- a/src/lib/containers/Background/Background.svelte
+++ b/src/lib/containers/Background/Background.svelte
@@ -12,7 +12,8 @@
 	export let dotSize = DOT_WIDTH; // Dot size when scale = 1
 	export let bgColor: CSSColorString | null = null;
 	export let dotColor: CSSColorString | null = null;
-	export let opacityThreshold = 1; // Scale after which the opacity of grid is reduced
+	export let opacityThreshold = 3; // Scale after which the opacity of grid is reduced
+	export let majorGrid = 0;
 
 	// External stores
 	const transforms = graph.transforms;
@@ -26,6 +27,7 @@
 	let backgroundOffsetX: number;
 	let backgroundOffsetY: number;
 	let gridOpacity: number = 1;
+	let majorGridOpacity: number = 1;
 
 	//Subscriptions
 	$: graphTranslation = $translationStore;
@@ -43,6 +45,7 @@
 		backgroundOffsetX = ((svgWidth + radius) * (1 - scale)) / 2 + graphTranslation.x;
 		backgroundOffsetY = ((svgHeight + radius) * (1 - scale)) / 2 + graphTranslation.y;
 		gridOpacity = scale > opacityThreshold ? 1 : scale / opacityThreshold;
+		majorGridOpacity = scale > opacityThreshold / 3 ? 1 : scale / (opacityThreshold / 3);
 	}
 </script>
 
@@ -70,14 +73,6 @@
 						cx={dotCenterCoordinate}
 						cy={dotCenterCoordinate}
 					/>
-				{:else if style === 'dual-dots'}
-					<circle
-						class="background-dot"
-						style:--calculated-dot-color={'red'}
-						r={radius}
-						cx={dotCenterCoordinate}
-						cy={dotCenterCoordinate}
-					/>
 				{:else if style === 'lines'}
 					<line
 						class="background-line"
@@ -99,8 +94,56 @@
 					/>
 				{/if}
 			</pattern>
+
+			{#if majorGrid > 0}
+				<pattern
+					id="graph-coarse-pattern"
+					x={backgroundOffsetX}
+					y={backgroundOffsetY}
+					width={gridScale * majorGrid}
+					height={gridScale * majorGrid}
+					patternUnits="userSpaceOnUse"
+				>
+					{#if style === 'dots'}
+						<circle
+							class="background-dot"
+							style:--calculated-dot-color={dotColor}
+							r={radius * 2}
+							cx={dotCenterCoordinate}
+							cy={dotCenterCoordinate}
+						/>
+					{:else if style === 'lines'}
+						<line
+							class="background-line"
+							style:--calculated-dot-color={dotColor}
+							x1={dotCenterCoordinate}
+							y1={0}
+							x2={dotCenterCoordinate}
+							y2={gridScale * majorGrid}
+							stroke-width={radius * 1.2}
+						/>
+						<line
+							class="background-line"
+							style:--calculated-dot-color={dotColor}
+							y1={dotCenterCoordinate}
+							x1={0}
+							y2={dotCenterCoordinate}
+							x2={gridScale * majorGrid}
+							stroke-width={radius * 1.2}
+						/>
+					{/if}
+				</pattern>
+			{/if}
 		</defs>
 		<rect width="100%" height="100%" fill="url(#graph-pattern)" opacity={gridOpacity} />
+		{#if majorGrid > 0}
+			<rect
+				width="100%"
+				height="100%"
+				fill="url(#graph-coarse-pattern)"
+				opacity={majorGridOpacity}
+			/>
+		{/if}
 	</svg>
 </div>
 

--- a/src/lib/containers/Background/Background.svelte
+++ b/src/lib/containers/Background/Background.svelte
@@ -67,8 +67,18 @@
 						cx={dotCenterCoordinate}
 						cy={dotCenterCoordinate}
 					/>
+				{:else if style === 'dual-dots'}
+					<circle
+						class="background-dot"
+						style:--calculated-dot-color={'red'}
+						r={radius}
+						cx={dotCenterCoordinate}
+						cy={dotCenterCoordinate}
+					/>
 				{:else if style === 'lines'}
 					<line
+						class="background-line"
+						style:--calculated-dot-color={dotColor}
 						x1={dotCenterCoordinate}
 						y1={0}
 						x2={dotCenterCoordinate}
@@ -76,6 +86,8 @@
 						stroke-width={radius}
 					/>
 					<line
+						class="background-line"
+						style:--calculated-dot-color={dotColor}
 						y1={dotCenterCoordinate}
 						x1={0}
 						y2={dotCenterCoordinate}
@@ -108,6 +120,11 @@
 	.background-dot {
 		fill: var(--calculated-dot-color, var(--dot-color, var(--default-dot-color)));
 	}
+
+	.background-line {
+		stroke: var(--calculated-dot-color, var(--dot-color, var(--default-dot-color)));
+	}
+
 	svg {
 		width: 100%;
 		height: 100%;

--- a/src/lib/containers/Background/Background.svelte
+++ b/src/lib/containers/Background/Background.svelte
@@ -12,6 +12,7 @@
 	export let dotSize = DOT_WIDTH; // Dot size when scale = 1
 	export let bgColor: CSSColorString | null = null;
 	export let dotColor: CSSColorString | null = null;
+	export let opacityThreshold = 1; // Scale after which the opacity of grid is reduced
 
 	// External stores
 	const transforms = graph.transforms;
@@ -24,6 +25,7 @@
 	let svgHeight;
 	let backgroundOffsetX: number;
 	let backgroundOffsetY: number;
+	let gridOpacity: number = 1;
 
 	//Subscriptions
 	$: graphTranslation = $translationStore;
@@ -40,6 +42,7 @@
 		svgHeight = backgroundWrapper?.offsetHeight || 0;
 		backgroundOffsetX = ((svgWidth + radius) * (1 - scale)) / 2 + graphTranslation.x;
 		backgroundOffsetY = ((svgHeight + radius) * (1 - scale)) / 2 + graphTranslation.y;
+		gridOpacity = scale > opacityThreshold ? 1 : scale / opacityThreshold;
 	}
 </script>
 
@@ -97,7 +100,7 @@
 				{/if}
 			</pattern>
 		</defs>
-		<rect width="100%" height="100%" fill="url(#graph-pattern)" />
+		<rect width="100%" height="100%" fill="url(#graph-pattern)" opacity={gridOpacity} />
 	</svg>
 </div>
 

--- a/src/lib/types/general.ts
+++ b/src/lib/types/general.ts
@@ -60,7 +60,7 @@ export interface ActiveKeys {
 	[key: string]: boolean | number;
 }
 
-export type BackgroundStyles = 'lines' | 'dots' | 'dual-dots' | 'none';
+export type BackgroundStyles = 'lines' | 'dots' | 'none';
 
 export interface ActiveIntervals extends Record<string, NodeJS.Timer | undefined> {
 	[key: string]: NodeJS.Timer | undefined;

--- a/src/lib/types/general.ts
+++ b/src/lib/types/general.ts
@@ -60,7 +60,7 @@ export interface ActiveKeys {
 	[key: string]: boolean | number;
 }
 
-export type BackgroundStyles = 'lines' | 'dots' | 'none';
+export type BackgroundStyles = 'lines' | 'dots' | 'dual-dots' | 'none';
 
 export interface ActiveIntervals extends Record<string, NodeJS.Timer | undefined> {
 	[key: string]: NodeJS.Timer | undefined;

--- a/src/routes/connections/+page.svelte
+++ b/src/routes/connections/+page.svelte
@@ -43,7 +43,7 @@
 			connections={[2, 3, '4', [5, '1'], 6, ['custom', 'custom']]}
 		/>
 
-		<Background style="lines" slot="background" />
+		<Background style="dots" slot="background" />
 	</Svelvet>
 </body>
 

--- a/src/routes/connections/+page.svelte
+++ b/src/routes/connections/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { Svelvet, Minimap, Node, Anchor } from '$lib';
+	import { Svelvet, Minimap, Node, Anchor, Background } from '$lib';
 	import CustomEdge from '../../example-components/CustomEdge.svelte';
 	function getPosition() {
 		return {
@@ -42,6 +42,8 @@
 			position={{ x: 0, y: 600 }}
 			connections={[2, 3, '4', [5, '1'], 6, ['custom', 'custom']]}
 		/>
+
+		<Background style="lines" slot="background" />
 	</Svelvet>
 </body>
 

--- a/src/routes/connections/+page.svelte
+++ b/src/routes/connections/+page.svelte
@@ -43,7 +43,7 @@
 			connections={[2, 3, '4', [5, '1'], 6, ['custom', 'custom']]}
 		/>
 
-		<Background style="dots" slot="background" />
+		<Background style="dots" majorGrid={4} slot="background" />
 	</Svelvet>
 </body>
 


### PR DESCRIPTION
This PR adds a couple of enhancements/features to the `<Background />` grid element:

- fill changed to stroke in `style="line"`. Didn't seem to work in current format.
- Adds option to have a major and minor grid. By default, prop `majorGrid = 0`, setting to a larger integer will overlay a major grid.
- Add opacity threshold for grid under certain scales. When zooming out past a preset threshold (set by prop `opacityThreshold`), the grid is faded out. Makes the canvas look less cluttered when zoomed out far.

The progress of this project recently has been very impressive! excited to see it develop further!