### PR TITLE
Add missing quotation mark in Background component documentation

### DIFF
--- a/docs/components/background.mdx
+++ b/docs/components/background.mdx
@@ -16,7 +16,7 @@ The Background component is configurable via props and can be passed to the Svel
 
 <Svelvet controls minimap>
     <Node />
-    <Background dotColor="red" bgColor="black gridWidth={40} dotSize={3} slot="background" />
+    <Background dotColor="red" bgColor="black" gridWidth={40} dotSize={3} slot="background" />
 </Svelvet>
 ```
 


### PR DESCRIPTION
I've added missing quotation mark ".