### PR TITLE
Enable limited touch support

### DIFF
--- a/src/lib/components/Anchor/Anchor.svelte
+++ b/src/lib/components/Anchor/Anchor.svelte
@@ -217,7 +217,7 @@
 		previousConnectionCount = $connectedAnchors.size;
 	}
 
-	function handleMouseUp(e: MouseEvent) {
+	function handleMouseUp(e: MouseEvent | TouchEvent) {
 		if (connecting) return; // If the anchor initiated the connection, do nothing
 
 		// If the anchor receiving the event has connections
@@ -233,7 +233,7 @@
 		if ($connectingFrom) connectEdge(e);
 	}
 
-	function handleClick(e: MouseEvent) {
+	function handleClick(e: MouseEvent | TouchEvent) {
 		if (locked) return; // Return if the anchor is locked
 
 		// If the Anchor being clicked has connections
@@ -285,7 +285,7 @@
 		edgeStore.add(newEdge, 'cursor');
 	}
 
-	function connectEdge(e: MouseEvent) {
+	function connectEdge(e: MouseEvent | TouchEvent) {
 		// Delete the temporary edge
 		edgeStore.delete('cursor');
 
@@ -528,6 +528,8 @@
 	on:mouseleave={() => (hovering = false)}
 	on:mousedown|stopPropagation|preventDefault={handleClick}
 	on:mouseup|stopPropagation={handleMouseUp}
+	on:touchstart|stopPropagation|preventDefault={handleClick}
+	on:touchend|stopPropagation={handleMouseUp}
 	bind:this={anchorElement}
 >
 	<slot linked={$connectedAnchors?.size >= 1} {hovering} {connecting}>


### PR DESCRIPTION
This PR adds very rudimentary support for creating edges on a touchscreen device.

Currently, the user must touch the start and end point separately, rather than drag between them.
This means that you don't get the interactive 'following' of a touch drag event.

I'm not sure what the best approach is for mobile-friendly graph editing. As I develop my own project I'm happy to make the touch support better in the future. This PR is a 'short-term' fix to enable limited touchscreen interactions.