### PR TITLE
allow to override blocked cursor

### DIFF
--- a/docs/styling.mdx
+++ b/docs/styling.mdx
@@ -53,6 +53,10 @@ Scroll to the bottom for example code.
 	Icon displayed when the cursor is over a Node component
 </ResponseField>
 
+<ResponseField name="--node-cursor-blocked" default="not-allowed">
+	Icon displayed when the cursor is over a Node component which is blocked
+</ResponseField>
+
 <ResponseField name="--node-width" default="200px">
 	Width of the default Node
 </ResponseField>

--- a/src/lib/components/Node/InternalNode.svelte
+++ b/src/lib/components/Node/InternalNode.svelte
@@ -359,7 +359,7 @@
 	}
 
 	.locked {
-		cursor: not-allowed;
+		cursor: var(--node-cursor-blocked, var(--default-node-cursor-blocked));
 	}
 	.selected {
 		box-shadow: 0 0 0 var(--final-border-width) var(--final-selection-color),

--- a/src/lib/containers/Svelvet/Svelvet.svelte
+++ b/src/lib/containers/Svelvet/Svelvet.svelte
@@ -193,6 +193,7 @@
 		--default-node-border-radius: 10px;
 
 		--default-node-cursor: grab;
+		--default-node-cursor-blocked: not-allowed;
 		--default-background-cursor: move;
 
 		--default-anchor-border-width: 1px;

--- a/src/routes/styling/+page.svelte
+++ b/src/routes/styling/+page.svelte
@@ -14,6 +14,7 @@
 		/>
 		<Node --node-color="red" --node-border-radius="40px" id="node2" label="test" />
 		<Node label="what" position={{ x: 10, y: 200 }} inputs={3} TD />
+		<Node label="what" position={{ x: 100, y: 200 }} inputs={2} TD blocked />
 		<ThemeToggle slot="toggle" main="light" alt="custom-theme" />
 	</Svelvet>
 </body>
@@ -27,6 +28,7 @@
 	}
 
 	:root[svelvet-theme='custom-theme'] {
+		--node-cursor-blocked: crosshair;
 		--node-color: hsl(225, 30%, 50%);
 		--node-border-color: hsl(225, 20%, 40%);
 		--node-selection-color: hsl(45, 90%, 60%);


### PR DESCRIPTION
Allow users to override the used cursor for blocked nodes. Specify the css property (variable) node-cursor-blocked in order to override the default not allowed one.