### PR TITLE
Fix locking for incoming connections

### DIFF
--- a/src/lib/components/Anchor/Anchor.svelte
+++ b/src/lib/components/Anchor/Anchor.svelte
@@ -289,9 +289,10 @@
 
 		// If the anchor receiving the event has connections
 		// And it can't have multiple connections
+		// Or the anchor is locked
 		// Then this is an invalid connection
 		// Delete the cursor edge and clear the linking store
-		if ($connectedAnchors?.size && !multiple) {
+		if (locked || ($connectedAnchors?.size && !multiple)) {
 			edgeStore.delete('cursor');
 			if (!e.shiftKey) clearLinking(false);
 			return;
@@ -598,7 +599,7 @@
 	tabindex="0"
 	class:locked
 	title={title || ''}
-	on:mouseenter={() => (hovering = true)}
+	on:mouseenter={() => (hovering = true && !locked)}
 	on:mouseleave={() => (hovering = false)}
 	on:mousedown|stopPropagation|preventDefault={handleClick}
 	on:mouseup|stopPropagation={handleMouseUp}


### PR DESCRIPTION
The `Anchor` component has a `locked` property that prevents outgoing edges from being created.
However, the option does not disable edges from other nodes from being connected to it.

This PR prevents any edge creation, plus prevents the hovering styling from being applied to the locked anchor. 