### PR TITLE
Fix a bunch of warnings

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,7 @@
 .DS_Store
 node_modules
 /build
+/dist
 /.svelte-kit
 /package
 .env

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Shout out to our contributors! Here's what's new:
   <li>Added custom classes for edges to allow for uniform styling</li>
   <li>Added click event for edges that execute a user-defined callback</li>
   <li>Added functionality to edit edges by right-clicking on a node to bring up a modal</li>
-  <li>Added feature to expand and collapse tree nodes. 
+  <li>Added feature to expand and collapse tree nodes.</li>
   <li>Updated documentation page on website to include new features</li>
   <li>Updated home page to include newest collaborators</li>
   <li>Solved github issue #s: </li>

--- a/src/lib/components/Drawer/DrawerAnchor.svelte
+++ b/src/lib/components/Drawer/DrawerAnchor.svelte
@@ -94,7 +94,7 @@
 		return;
 	};
 
-	//Button Clicks for Anchors
+	// Button Clicks for Anchors
 	const handleAnchorLockedButtonClick = (e: Event) => {
 		const target = e.target as HTMLInputElement;
 		anchorLocked = target.checked;
@@ -171,7 +171,8 @@
 		if (addAnchorID === 'addLeftAnchor') leftAnchorCounter.set(anchorsCreated.left.length);
 		else if (addAnchorID === 'addRightAnchor') rightAnchorCounter.set(anchorsCreated.right.length);
 		else if (addAnchorID === 'addTopAnchor') topAnchorCounter.set(anchorsCreated.top.length);
-		else if (addAnchorID === 'addBottomAnchor') bottomAnchorCounter.set(anchorsCreated.bottom.length);
+		else if (addAnchorID === 'addBottomAnchor')
+			bottomAnchorCounter.set(anchorsCreated.bottom.length);
 		else if (addAnchorID === 'addSelfAnchor') selfAnchorCounter.set(anchorsCreated.self.length);
 	};
 	// Deletes anchor based on the id of the button clicked
@@ -283,12 +284,22 @@
 			</li>
 
 			<li class="list-item">
-				<label for="addAnchors"> Add Anchors: </label>
-				<button id="deleteSelfAnchor" class="deleteAnchor" type="button" on:click|stopPropagation={deleteAnchor}>
+				<label for="addAnchors">Add Anchors: </label>
+				<button
+					id="deleteSelfAnchor"
+					class="deleteAnchor"
+					type="button"
+					on:click|stopPropagation={deleteAnchor}
+				>
 					<Icon icon="arrow_left" />
 				</button>
 				<span class="list-item counter">{$selfAnchorCounter}</span>
-				<button id="addSelfAnchor" class="addAnchor" type="button" on:click|stopPropagation={addAnchor}>
+				<button
+					id="addSelfAnchor"
+					class="addAnchor"
+					type="button"
+					on:click|stopPropagation={addAnchor}
+				>
 					<Icon icon="arrow_right" />
 				</button>
 			</li>
@@ -429,7 +440,7 @@
 		width: 15px;
 		margin: 0 10px;
 		font-size: 18px;
-	} 
+	}
 
 	.anchorResetBtn {
 		color: var(

--- a/src/lib/renderers/GroupBoxRenderer/GroupBoxRenderer.svelte
+++ b/src/lib/renderers/GroupBoxRenderer/GroupBoxRenderer.svelte
@@ -9,5 +9,11 @@
 </script>
 
 {#each Array.from($groupBoxes) as [id, group] (id)}
-	<GroupBoundingBox on:groupClick {...group} groupName={id} />
+	<GroupBoundingBox
+		on:groupClick
+		dimensions={group.dimensions}
+		position={group.position}
+		color={group.color}
+		groupName={id}
+	/>
 {/each}

--- a/src/routes/cursor-drop/+page.svelte
+++ b/src/routes/cursor-drop/+page.svelte
@@ -124,6 +124,7 @@
 	};
 </script>
 
+<!-- svelte-ignore a11y-no-static-element-interactions -->
 <div
 	class={dropZoneClass}
 	on:dragover={onDragOver}
@@ -174,6 +175,7 @@
 				Centered: <input type="checkbox" bind:value={center} on:change={handleCenterButtonClick} />
 			</li>
 			<li class="list-item">
+				<!-- svelte-ignore a11y-no-static-element-interactions -->
 				<div id="createNode" draggable="true" on:dragstart={onDragStart}>Node</div>
 			</li>
 			<li>

--- a/src/routes/drawer/+page.svelte
+++ b/src/routes/drawer/+page.svelte
@@ -327,6 +327,7 @@
 	};
 </script>
 
+<!-- svelte-ignore a11y-no-static-element-interactions -->
 <div
 	id="drop_zone"
 	on:dragenter={handleDragEnter}
@@ -354,6 +355,7 @@
 		<h2>Nodes</h2>
 		<ul>
 			<li class="list-item">
+				<!-- svelte-ignore a11y-no-static-element-interactions -->
 				<div
 					class="defaultNodes"
 					draggable="true"


### PR DESCRIPTION
- a11y warnings
- close `<li>` in README.md
- formatting
- ignore `./dist` to pass lint with success
- Svelte emits warnings about unknown props when using Group component