### PR TITLE
Fix e2e tests discovery

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,7 +5,8 @@ const config: PlaywrightTestConfig = {
 		command: 'npm run build && npm run preview',
 		port: 4173
 	},
-	testDir: 'tests/e2e-tests'
+	testDir: 'tests/e2e-tests',
+	testMatch: '*.ts'
 };
 
 export default config;


### PR DESCRIPTION
Svelvet uses unconventional naming for tests that requires testMatch rule to be set.

BTW I think it will better to rename `tests/e2e-tests` to `tests/e2e` and to rename `anchor\test.ts` to anchor.spec.ts to avoid useless directory and `testMatch`.