### PR TITLE
Fix: in Svelte 4+ let:destroy is not passed to Edge's "label" slot

### DIFF
--- a/docs/components/edge.mdx
+++ b/docs/components/edge.mdx
@@ -29,7 +29,7 @@ Edges also accept callback functions that run in response to click events on the
 
 <Edge let:path edgeClick="{() => alert('Edge clicked')}" step>
 	<path d={path} />
-	<-- Note that let:destroy must be specified on the component placed in the named slot, not on the parent-->
+	<!-- Note that let:destroy must be specified on the component placed in the named slot, not on the parent -->
 	<button slot="label" let:destroy on:click={destroy}>
 		<p>Custom Label</p>
 	</button>

--- a/docs/components/edge.mdx
+++ b/docs/components/edge.mdx
@@ -27,9 +27,10 @@ Edges also accept callback functions that run in response to click events on the
 	import { Edge } from 'svelvet';
 </script>
 
-<Edge let:path let:destroy edgeClick="{() => alert('Edge clicked')}" step>
+<Edge let:path edgeClick="{() => alert('Edge clicked')}" step>
 	<path d={path} />
-	<button on:click={destroy} slot="label">
+	<-- Note that let:destroy must be specified on the component placed in the named slot, not on the parent-->
+	<button slot="label" let:destroy on:click={destroy}>
 		<p>Custom Label</p>
 	</button>
 </Edge>

--- a/src/lib/components/Edge/Edge.svelte
+++ b/src/lib/components/Edge/Edge.svelte
@@ -330,7 +330,7 @@
 		{#if renderLabel}
 			<foreignObject x={labelPoint.x} y={labelPoint.y} width="100%" height="100%">
 				<span class="label-wrapper">
-					<slot name="label">
+					<slot name="label" {destroy} {hovering}>
 						<div
 							class="default-label"
 							style:--prop-label-color={labelColor}


### PR DESCRIPTION
Relevant change in Svelte 4 migration guide: https://svelte.dev/docs/v4-migration-guide#default-slot-bindings

I have added minimal fix and updated the docs for that feature. Not sure what else to do here, maintainers please advise :)