### PR TITLE
fix: fixed an error that current graph state cannot be exported into JSON correctly

### DIFF
--- a/src/lib/components/ThemeToggle/ThemeToggle.svelte
+++ b/src/lib/components/ThemeToggle/ThemeToggle.svelte
@@ -62,13 +62,13 @@
 	let graph: any;
 
 	graphStore.subscribe((graphMap) => {
-		const graphKey = 'G-1';
+		const graphKey = 'G-G-1';
 		graph = graphMap.get(graphKey);
 		// console.log('Graph from store:', graph);
 	});
 	function logCurrentGraphState() {
 		const currentGraphMap = get(graphStore);
-		const graph = currentGraphMap.get('G-1');
+		const graph = currentGraphMap.get('G-G-1');
 		// if (graph) {
 		// 	console.log('Current Graph State:', graph);
 		// } else {


### PR DESCRIPTION
## Description
When clicking the 'save' button in the `ThemeToggle` component, the `getJSONState` function will throw an error that the `graph` parameter is empty. This error is caused by getting the graph info with the incorrect `graphKey`; update it with the correct value will fix it.


## Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I've followed the [Contributing guidelines](https://github.com/open-source-labs/.github/blob/main/docs/CONTRIBUTING.md)

- [x] I've titled my PR according to the [Conventional Commits spec](https://conventionalcommits.org)
- [x] I've linted and tested my code
