### PR TITLE
 FIX: Edges appending to only one instance of Svelvet container #513

### DIFF
--- a/src/lib/components/Edge/Edge.svelte
+++ b/src/lib/components/Edge/Edge.svelte
@@ -8,19 +8,25 @@
 	import type { CSSColorString, Direction, EdgeStyle, EndStyle, Graph } from '$lib/types';
 	import type { WritableEdge } from '$lib/types';
 
+	export let containerId;
+
 	let animationFrameId: number;
 
-	function moveEdge(edgeElement: SVGElement) {
+	function moveEdge(edgeElement: SVGElement, containerId: string) {
 		const parentNode = edgeElement.parentNode;
 		if (!parentNode) return;
 		// Remove the anchor from its current container
 		parentNode.removeChild(edgeElement);
 
 		// Add the anchor to the new container
-		const newContainer = document.querySelector(`.svelvet-graph-wrapper`);
+		const newContainer = document.querySelector(`.svelvet-graph-wrapper[data-id='${containerId}']`);
 		if (!newContainer) return;
 		newContainer.appendChild(edgeElement);
 	}
+
+	onDestroy(() => {
+		cancelAnimationFrame(animationFrameId);
+	});
 </script>
 
 <script lang="ts">


### PR DESCRIPTION
- Updated moveEdge function in Edge.svelte to correctly append the edge element to its respective Svelvet container based on containerId.


 🔗 Linked issue

Resolves #513 

 Description

- Enhanced moveEdge function in Edge.svelte to ensure proper appending of edge elements to their respective Svelvet containers.
- Previous implementation relied on static container selection, causing edges to append inconsistently across multiple Svelvet instances.
- Refactored moveEdge to dynamically fetch the container using containerId, ensuring edges are appended to the correct instance based on context.
- This change resolves visual inconsistencies and improves the reliability of edge rendering in complex Svelvet applications.


## Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I've followed the [Contributing guidelines](https://github.com/open-source-labs/.github/blob/main/docs/CONTRIBUTING.md)

- [x] I've titled my PR according to the [Conventional Commits spec](https://conventionalcommits.org)
- [x] I've linked an open issue
- [x] I've linted and tested my code
