### PR TITLE
fix:Replace self-closing Anchor elements with one open and close brackets

### DIFF
--- a/docs/components/edge.mdx
+++ b/docs/components/edge.mdx
@@ -53,9 +53,9 @@ Edges also accept callback functions that run in response to click events on the
 <Svelvet>
     <Node>
         <div class="my-node">
-            <Anchor />
-				<MyEdge slot="edge"/>
-			<Anchor />
+            <Anchor>
+                <MyEdge slot="edge" />
+            </Anchor>
         </div>
     </Node>
 </Svelvet>


### PR DESCRIPTION
<!---
☝️ Prefix your PR title with `fix:`, `feat:`, `docs:`, or other according to the Conventional Commits spec:
https://conventionalcommits.org

👉 Please make sure to follow our Contributing guidelines:
https://github.com/open-source-labs/.github/blob/main/docs/CONTRIBUTING.md
-->

## 🔗 Linked issue

None
 <!-- Resolves #123 -->

## Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->
Edge needs Anchor parent to work. I just copypasted example code into the editor and it didn't work.

Patched a silly mistake in docs.

## Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I've followed the [Contributing guidelines](https://github.com/open-source-labs/.github/blob/main/docs/CONTRIBUTING.md)

- [x] I've titled my PR according to the [Conventional Commits spec](https://conventionalcommits.org)
- [x] I've linked an open issue
- [ ] I've added tests that fail without this PR but pass with it
- [ ] I've linted and tested my code
- [x] I've updated documentation (if appropriate)
