### PR TITLE
Fix edge placement across multiple instances

### DIFF
--- a/src/lib/components/Edge/Edge.svelte
+++ b/src/lib/components/Edge/Edge.svelte
@@ -11,13 +11,7 @@
 	let animationFrameId: number;
 
 	function moveEdge(edgeElement: SVGElement) {
-		const parentNode = edgeElement.parentNode;
-		if (!parentNode) return;
-		// Remove the anchor from its current container
-		parentNode.removeChild(edgeElement);
-
-		// Add the anchor to the new container
-		const newContainer = document.querySelector(`.svelvet-graph-wrapper`);
+		const newContainer = edgeElement.closest('.svelvet-graph-wrapper');
 		if (!newContainer) return;
 		newContainer.appendChild(edgeElement);
 	}

--- a/src/routes/multiple-instances/+page.svelte
+++ b/src/routes/multiple-instances/+page.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+	import { Svelvet, Node } from '$lib';
+</script>
+
+<div class="graphs">
+	<div data-testid="graph-one">
+		<Svelvet id="graph-one" width={400} height={260}>
+			<Node id="one-source" label="One source" position={{ x: 40, y: 40 }} />
+			<Node id="one-target" label="One target" position={{ x: 240, y: 140 }} />
+		</Svelvet>
+	</div>
+
+	<div data-testid="graph-two">
+		<Svelvet id="graph-two" width={400} height={260}>
+			<Node id="two-source" label="Two source" position={{ x: 40, y: 40 }} />
+			<Node id="two-target" label="Two target" position={{ x: 240, y: 140 }} />
+		</Svelvet>
+	</div>
+</div>
+
+<style>
+	.graphs {
+		display: flex;
+		gap: 24px;
+		padding: 24px;
+	}
+
+	.graphs > div {
+		border: 1px solid #999;
+	}
+</style>

--- a/tests/e2e-tests/multiple-instances/test.ts
+++ b/tests/e2e-tests/multiple-instances/test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from '@playwright/test';
+
+test('edges render inside their own Svelvet instance', async ({ page }) => {
+	await page.goto('/multiple-instances');
+
+	await page.locator('[id="A-2/N-one-source"]').dragTo(page.locator('[id="A-1/N-one-target"]'));
+	await page.locator('[id="A-2/N-two-source"]').dragTo(page.locator('[id="A-1/N-two-target"]'));
+
+	const graphOne = page.getByTestId('graph-one').locator('.svelvet-graph-wrapper');
+	const graphTwo = page.getByTestId('graph-two').locator('.svelvet-graph-wrapper');
+
+	await expect(graphOne.locator('.edges-wrapper')).toHaveCount(1);
+	await expect(graphTwo.locator('.edges-wrapper')).toHaveCount(1);
+});


### PR DESCRIPTION
Fixes #513

## Summary
- Use the edge SVG's nearest `.svelvet-graph-wrapper` when moving it above nodes instead of querying the first wrapper in the document.
- Add a `/multiple-instances` repro route with two independent Svelvet instances.
- Add a focused Playwright regression that connects one edge in each instance and asserts each graph wrapper owns one edge SVG.

## Verification
- `npx prettier --plugin-search-dir . --write src/lib/components/Edge/Edge.svelte src/routes/multiple-instances/+page.svelte tests/e2e-tests/multiple-instances/test.ts`
- `npm run build`
- `git diff --check`
- `PLAYWRIGHT_BROWSERS_PATH=0 ./node_modules/.bin/playwright install chromium`
- `PLAYWRIGHT_BROWSERS_PATH=0 ./node_modules/.bin/playwright test tests/e2e-tests/multiple-instances/test.ts` could not complete in this Codex macOS sandbox because Chromium exits with SIGABRT immediately after launch, before the test body runs.
- `npm run check` still fails on existing repo-wide Svelte/TypeScript errors unrelated to this change.